### PR TITLE
support multiple reemit statements for same match

### DIFF
--- a/examples/multiple_reemit.conf
+++ b/examples/multiple_reemit.conf
@@ -20,6 +20,17 @@
   </store>
 </match>
 
+
+<match gc_stat>
+  type copy
+  <store>
+    type stdout
+  </store>
+  <store>
+    type reemit
+  </store>
+</match>
+
 <match **>
   type stdout
 </match>

--- a/examples/multiple_reemit.conf
+++ b/examples/multiple_reemit.conf
@@ -27,7 +27,7 @@
     type stdout
   </store>
   <store>
-    type reemit
+    type reemit # re-emitted messages are not absorbed by <match **> OR the <match gc_stat>
   </store>
 </match>
 

--- a/fluent-plugin-reemit.gemspec
+++ b/fluent-plugin-reemit.gemspec
@@ -3,7 +3,7 @@ $:.push File.expand_path('../lib', __FILE__)
 
 Gem::Specification.new do |gem|
   gem.name        = "fluent-plugin-reemit"
-  gem.version     = "0.1.0"
+  gem.version     = "0.1.1"
   gem.authors     = ["Naotoshi Seo"]
   gem.email       = "sonots@gmail.com"
   gem.homepage    = "https://github.com/sonots/fluent-plugin-reemit"


### PR DESCRIPTION
currently, if you have multiple reemit statements for the same match the second reemit will actually reemit to the first one, causing infinite looping and sadness. 

this fixes that issue, so a second (or third, or Nth) reemit will emit to the next matcher after itself - rather than the first matcher that matches that isn't itself (which might be before it).

