### PR TITLE
Fix Pipeline

### DIFF
--- a/lib/fluent/plugin/out_reemit.rb
+++ b/lib/fluent/plugin/out_reemit.rb
@@ -1,3 +1,5 @@
+require 'fluent/event_router'
+
 module Fluent
   class ReemitOutput < Output
     Fluent::Plugin.register_output('reemit', self)
@@ -80,7 +82,7 @@ module Fluent
           if rule.match?(tag)
             if found_reemit && !@reemit.included?(rule.collector)
               if rule.collector.is_a?(Filter)
-                pipeline ||= Pipeline.new
+                pipeline ||= EventRouter::Pipeline.new
                 pipeline.add_filter(rule.collector)
               else
                 if pipeline


### PR DESCRIPTION
Fix emit transaction failed: error_class=NameError error="uninitialized constant Fluent::ReemitOutput::V12EventRouter::Pipeline"