### PR TITLE
spec: Fix broken create_driver sequence on v0.14

### DIFF
--- a/spec/out_reemit_spec.rb
+++ b/spec/out_reemit_spec.rb
@@ -1,11 +1,18 @@
 # encoding: UTF-8
 require_relative 'spec_helper'
 require 'fluent/plugin/out_copy'
+if Fluent::VERSION > '0.14'
+  require 'fluent/test/driver/multi_output'
+end
 
 describe Fluent::ReemitOutput do
   before { Fluent::Test.setup }
   def create_driver(config, tag = 'test')
-    Fluent::Test::OutputTestDriver.new(Fluent::CopyOutput, tag).configure(config)
+    if Fluent::VERSION > '0.14'
+      Fluent::Test::Driver::MultiOutput.new(Fluent::Plugin::CopyOutput).configure(config)
+    else
+      Fluent::Test::OutputTestDriver.new(Fluent::CopyOutput, tag).configure(config)
+    end
   end
 
   # THIS TEST IS ABSOLUTELY NOT ENOUGH. INSTEAD, RUN


### PR DESCRIPTION
Built-in `out_copy` plugin had been migrated to use v0.14 API.
This PR fixes creating test driver sequence on v0.14.